### PR TITLE
fixed code for deprecations, fixed code for int-float confusion

### DIFF
--- a/utils/gabor_filter.py
+++ b/utils/gabor_filter.py
@@ -40,6 +40,7 @@ def gabor_filter(im, orient, freq, kx=0.65, ky=0.65):
     sigma_x = 1/unfreq*kx
     sigma_y = 1/unfreq*ky
     block_size = np.round(3*np.max([sigma_x,sigma_y]))
+    block_size = int(block_size)
     array = np.linspace(-block_size,block_size,(2*block_size + 1))
     x, y = np.meshgrid(array, array)
 

--- a/utils/orientation.py
+++ b/utils/orientation.py
@@ -18,8 +18,8 @@ def calculate_angles(im, W, smoth=False):
     (y, x) = im.shape
 
     sobelOperator = [[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]]
-    ySobel = np.array(sobelOperator).astype(np.int)
-    xSobel = np.transpose(ySobel).astype(np.int)
+    ySobel = np.array(sobelOperator).astype(np.int_)
+    xSobel = np.transpose(ySobel).astype(np.int_)
 
     result = [[] for i in range(1, y, W)]
 


### PR DESCRIPTION

1. in orientation.py- due to deprecation of .int used .int_ in place of that for no errors
2. in gabor_filter.py- np.linspace(start, stop, num) requires num to be an integer. Even if block_size looks like an integer (e.g., 8.0), NumPy still treats it as a float (np.float64), which can’t be used as a loop count.
